### PR TITLE
Improve visuals and mobile controls

### DIFF
--- a/game.css
+++ b/game.css
@@ -10,6 +10,6 @@ body {
 }
 
 canvas {
-  border: 2px solid #000;
+  border: 2px solid yellow;
   display: block; /* Remove default inline whitespace */
 }

--- a/game.html
+++ b/game.html
@@ -100,21 +100,21 @@
         const dy = t.screenY - touchStartY;
         if (Math.abs(dx) > Math.abs(dy)) {
           if (dx > 30) {
-            window.dispatchEvent(
+            document.dispatchEvent(
               new KeyboardEvent('keydown', { key: 'ArrowRight' })
             );
           } else if (dx < -30) {
-            window.dispatchEvent(
+            document.dispatchEvent(
               new KeyboardEvent('keydown', { key: 'ArrowLeft' })
             );
           }
         } else {
           if (dy > 30) {
-            window.dispatchEvent(
+            document.dispatchEvent(
               new KeyboardEvent('keydown', { key: 'ArrowDown' })
             );
           } else if (dy < -30) {
-            window.dispatchEvent(
+            document.dispatchEvent(
               new KeyboardEvent('keydown', { key: 'ArrowUp' })
             );
           }

--- a/game.py
+++ b/game.py
@@ -237,6 +237,11 @@ def draw_everything():
     ctx.fillStyle = "#555"  # road color
     ctx.fillRect(0, 0, WIDTH, HEIGHT)
 
+    # Desert borders on the sides
+    ctx.fillStyle = "yellow"
+    ctx.fillRect(0, 0, DECOR_LEFT_X, HEIGHT)
+    ctx.fillRect(WIDTH - DECOR_LEFT_X, 0, DECOR_LEFT_X, HEIGHT)
+
     # Draw lane separators (dashed white lines)
     ctx.strokeStyle = "white"
     ctx.setLineDash([20, 15])
@@ -272,10 +277,26 @@ def draw_everything():
     for obs in obstacles:
         ctx.fillStyle = obs["color"]
         ctx.fillRect(obs["x"], obs["y"], obs["width"], obs["height"])
+        # wheels
+        ctx.fillStyle = "black"
+        ctx.beginPath()
+        ctx.arc(obs["x"] + 10, obs["y"] + obs["height"] - 5, 5, 0, 2 * window.Math.PI)
+        ctx.fill()
+        ctx.beginPath()
+        ctx.arc(obs["x"] + obs["width"] - 10, obs["y"] + obs["height"] - 5, 5, 0, 2 * window.Math.PI)
+        ctx.fill()
 
     # Draw player
     ctx.fillStyle = PLAYER_COLOR
     ctx.fillRect(player_x, player_y, PLAYER_WIDTH, PLAYER_HEIGHT)
+    # player wheels
+    ctx.fillStyle = "black"
+    ctx.beginPath()
+    ctx.arc(player_x + 10, player_y + PLAYER_HEIGHT - 5, 5, 0, 2 * window.Math.PI)
+    ctx.fill()
+    ctx.beginPath()
+    ctx.arc(player_x + PLAYER_WIDTH - 10, player_y + PLAYER_HEIGHT - 5, 5, 0, 2 * window.Math.PI)
+    ctx.fill()
     if has_shield:
         ctx.strokeStyle = "cyan"
         ctx.lineWidth = 5


### PR DESCRIPTION
## Summary
- change canvas border to yellow so the road resembles desert
- draw yellow desert edges on both sides of the road
- add simple black wheels to cars so they look more like vehicles
- dispatch keyboard events from swipe gestures to `document` for better mobile control

## Testing
- `python3 -m py_compile game.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff3866a0c833199a8acb3293377ae